### PR TITLE
New template scheme for fused transposes

### DIFF
--- a/bench/fft_bench.cpp
+++ b/bench/fft_bench.cpp
@@ -111,10 +111,10 @@ void process_neon(benchmark::State& state, std::array<std::complex<float>, N>& t
     }
 
     // Make sure to do initialization
-    volatile auto fft_plan_n = FFT::FFTPlan<N, float32x2_t>();
+    FFT::FFTPlan<float32x2_t>::Init<N>();
 
     for (auto _ : state) {
-        FFT::FFTPlan<N, float32x2_t>::fft(temp_time_domain.data(), temp_freq_domain.data());
+        FFT::FFTPlan<float32x2_t>::fft<N>(temp_time_domain.data(), temp_freq_domain.data());
     }
 }
 
@@ -123,10 +123,10 @@ void process_stdcomplexwrap(benchmark::State& state, std::array<std::complex<flo
     std::array<FFT::StdComplexWrap<float>, N> temp_freq_domain;
 
     // Make sure to do initialization
-    volatile auto fft_plan_n = FFT::FFTPlan<N, FFT::StdComplexWrap<float>>();
+    FFT::FFTPlan<FFT::StdComplexWrap<float>>::Init<N>();
 
     for (auto _ : state) {
-        FFT::FFTPlan<N, FFT::StdComplexWrap<float>>::fft(
+        FFT::FFTPlan<FFT::StdComplexWrap<float>>::fft<N>(
             static_cast<FFT::StdComplexWrap<float>*>(time_domain.data()),
             temp_freq_domain.data()
         );
@@ -143,10 +143,10 @@ void process_customcomplex(benchmark::State& state, std::array<std::complex<floa
     }
 
     // Make sure to do initialization
-    volatile auto fft_plan_n = FFT::FFTPlan<N, FFT::Complex>();
+    FFT::FFTPlan<FFT::Complex>::Init<N>();
 
     for (auto _ : state) {
-        FFT::FFTPlan<N, FFT::Complex>::fft(temp_time_domain.data(), temp_freq_domain.data());
+        FFT::FFTPlan<FFT::Complex>::fft<N>(temp_time_domain.data(), temp_freq_domain.data());
     }
 }
 

--- a/bench/fft_comp_unit.cpp
+++ b/bench/fft_comp_unit.cpp
@@ -3,25 +3,25 @@
 
 namespace FFT {
     void fft_2(Complex* __restrict__ in, Complex* __restrict__ out) noexcept { 
-        FFT::FFTPlan<2, Complex>::fft(in, out);
+        FFT::FFTPlan<Complex>::fft<2>(in, out);
     }
     void fft_3(Complex* __restrict__ in, Complex* __restrict__ out) noexcept {
-        FFT::FFTPlan<3, Complex>::fft(in, out);
+        FFT::FFTPlan<Complex>::fft<3>(in, out);
     }
     void fft_4(Complex* __restrict__ in, Complex* __restrict__ out) noexcept {
-        FFT::FFTPlan<4, Complex>::fft(in, out);
+        FFT::FFTPlan<Complex>::fft<4>(in, out);
     }
     void fft_5(Complex* __restrict__ in, Complex* __restrict__ out) noexcept {
-        FFT::FFTPlan<5, Complex>::fft(in, out);
+        FFT::FFTPlan<Complex>::fft<5>(in, out);
     }
     void fft_6(Complex* __restrict__ in, Complex* __restrict__ out) noexcept {
-        FFT::FFTPlan<6, Complex>::fft(in, out);
+        FFT::FFTPlan<Complex>::fft<6>(in, out);
     }
     void fft_7(Complex* __restrict__ in, Complex* __restrict__ out) noexcept {
-        FFT::FFTPlan<7, Complex>::fft(in, out);
+        FFT::FFTPlan<Complex>::fft<7>(in, out);
     }
     void fft_8(Complex* __restrict__ in, Complex* __restrict__ out) noexcept {
-        FFT::FFTPlan<8, Complex>::fft(in, out);
+        FFT::FFTPlan<Complex>::fft<8>(in, out);
     }
 }
         

--- a/bench/fft_profile.cpp
+++ b/bench/fft_profile.cpp
@@ -11,10 +11,10 @@ int main() {
     std::array<FFT::Complex, N> freq_domain = {0};
     FFT::wave_gen_lcg(time_domain.data(), freq_domain_ans.data(), N);
 
-    volatile auto fft_plan_n = FFT::FFTPlan<N, FFT::Complex>();
+    FFT::FFTPlan<FFT::Complex>::Init<N>();
     //ProfilerStart("fft_mid_prime");
     for (std::size_t i = 0; i < 100000000; i++) {
-        FFT::FFTPlan<N, FFT::Complex>::fft(time_domain.data(), freq_domain.data());
+        FFT::FFTPlan<FFT::Complex>::fft<N>(time_domain.data(), freq_domain.data());
     }
     //ProfilerStop();
 }

--- a/flake.nix
+++ b/flake.nix
@@ -37,16 +37,13 @@
     in rec {
       devShells.default = pkgs.mkShell {
         buildInputs = [
-          pkgs.clang
           pkgs.git
           doctest
           googlebench
-          pkgs.libcxx
           pkgs.fftwFloat
           pkgs.gperftools
           pkgs.graphviz
           pkgs.gv
-          pkgs.llvmPackages_latest.llvm
         ];
 
         # With -O3 the compiler optimizes out some recusrsive fft transposition steps

--- a/src/fft.hpp
+++ b/src/fft.hpp
@@ -17,6 +17,45 @@
 #define MCA_END __asm volatile("# LLVM-MCA-END");
 
 namespace FFT {
+
+    /// Signal generation for generating an FFT input with the corresponding expected output.
+    constexpr double TwoPI = 2.0 * M_PI;
+    
+    template <typename T>
+    constexpr void wave_gen(T *time_domain, T *freq_domain,
+        std::size_t N,
+        unsigned int f = 1,
+        unsigned int phase = 0,
+        unsigned int amp = 1) {
+        for (unsigned int i = 0; i < N; i++) {
+            const float angle = static_cast<float>(TwoPI) * static_cast<float>((i * f) + phase)
+                                  / static_cast<float>(N);
+            time_domain[i] += T{std::cosf(angle), std::sinf(angle)} * static_cast<float>(amp);
+        }
+        const float angle = static_cast<float>(TwoPI) * 
+                                  (static_cast<float>(phase) / static_cast<float>(N));
+        freq_domain[f] += T{std::cosf(angle), std::sinf(angle)} * static_cast<float>(amp);
+    } 
+
+    template <typename T>
+    constexpr void wave_gen_lcg(T *time_domain, T *freq_domain, unsigned int N) {
+        if (N < 13) {
+            if (N > 7) wave_gen(time_domain, freq_domain, N, 7, 2, 1);
+            if (N > 5) wave_gen(time_domain, freq_domain, N, 5, 2, 1);
+            if (N > 4) wave_gen(time_domain, freq_domain, N, 4, 3, 2);
+            if (N > 3) wave_gen(time_domain, freq_domain, N, 3, 2, 1);
+            wave_gen(time_domain, freq_domain, N, 1, 1, 1);
+            return;
+        } else {
+            for (unsigned int i = 0; i < 13; i++) {
+                wave_gen(time_domain, freq_domain, N,
+                    ((i + 7) * 3) % N,
+                    ((i + 5) * 11) % N,
+                    ((i + 11) * 13) % N);
+            }
+        }
+    }
+
     /// Operations used by FFT
     template <typename T>
     inline float abs(const T &__restrict__ a) noexcept {
@@ -42,38 +81,62 @@ namespace FFT {
         return {a[0] * b_conj[0] + a[1] * b_conj[1], a[1] * b_conj[0] - a[0] * b_conj[1]};
     }
 
-    // These are the factors from highest priority to lowest priority, with
-    //  with the highest priority at the lowest index
-    constexpr unsigned int factors[] = {8, 4, 6};
-    constexpr unsigned int get_best_factor(unsigned int N) {
-        for (auto factor : factors) {
-            if (N % factor == 0)
-                return factor;
+    /// FFT factor generation
+    template<typename T>
+    struct FFTFactorGen {
+        // For this type parameter, these are the factors, from highest priority to
+        //  lowest priority, to create each layer of the FFT.
+        static constexpr unsigned int factors[] = {8, 4, 6};
+
+        // Given an input of size N, return the FFT bin sizes of the next
+        //  layer of the FFT.
+        static constexpr unsigned int get_best_factor(unsigned int N) {
+            for (auto factor : factors) {
+                if (N % factor == 0)
+                    return factor;
+            }
+            return prime_factor::get_prime_factor(N);
         }
-        return prime_factor::get_prime_factor(N);
+    };
+
+    /// FFT coefficient generation
+    constexpr double NegTwoPI = -TwoPI;
+
+    template<typename T, unsigned int N>
+    void populate_dft_matrix_by_angle(T *mat) {
+        for (std::size_t i = 0; i < N; i++) {
+            for (std::size_t j = 0; j < N; j++) {
+                const double angle = 
+                    NegTwoPI * static_cast<double>((i * j) % N) / static_cast<double>(N);
+                    mat[i * N + j] = T{static_cast<float>(std::cos(angle)),
+                                          static_cast<float>(std::sin(angle))};
+            }
+        }
+    }
+    
+    template<typename T, unsigned int N>
+    void populate_twiddle_factors_by_angle(T* factors) {
+        for (std::size_t i = 0; i < N; i++) {
+            const double angle = NegTwoPI * static_cast<double>(i) / static_cast<double>(N);
+            factors[i] = T{static_cast<float>(std::cos(angle)), static_cast<float>(std::sin(angle))};
+        }
     } 
     
-    constexpr double TwoPI = 2.0 * M_PI;
-    constexpr double NegTwoPI = -TwoPI; 
-
-    template <unsigned int N, typename T>
+    template <typename T>
     class FFTPlan {
-        private:
+        public:
+        // Multiplication op aliases for type parameter
         static constexpr auto m = mult<T>;
         static constexpr auto mc = mult_conj<T>;
-        public:
-        static constexpr unsigned int A = get_best_factor(N);
-        static constexpr unsigned int B = N / A; 
 
-        FFTPlan() {
-            // Ensure the coeffs are calculated
-            volatile auto* coefs = gen_coefs_by_angle();
-        }
+        template<unsigned int N>
+        static void Init() { FFTLayer<N>::Init(); }
 
-        // NOTE : The result is not shifted so the DC component is still at index 0,
+        // The result is not shifted so the DC component is still at index 0,
         //  and the FFT and IFFT are inverses of each other
+        template<unsigned int N>
         static void fft(T *__restrict__ in, T *__restrict__ out) noexcept {
-            fft_recurse(in, out);
+            FFTLayer<N>::fft_recurse(in, out);
 
             // Normalize
             for (std::size_t i = 0; i < N; i++)
@@ -84,11 +147,12 @@ namespace FFT {
 
         // The Inverse DFT matrix is the same as the DFT matrix but with the corresponding
         //  factors conjugated.
+        template<unsigned int N>
         static void ifft(T *__restrict__ in, T *__restrict__ out) noexcept {
             for (std::size_t i = 0; i < N; i++)
                 in[i] = conj(in[i]);
 
-            fft_recurse(in, out);
+            FFTLayer<N>::fft_recurse(in, out);
 
             for (std::size_t i = 0; i < N; i++)
                 out[i] = conj(out[i]);
@@ -98,20 +162,131 @@ namespace FFT {
 
             return;
         }
+
+        private:
+
+        template<unsigned int N>
+        struct FFTLayer {
+            static constexpr unsigned int A = FFTFactorGen<T>::get_best_factor(N);
+            static constexpr unsigned int B = N / A;
+
+            static void Init() {
+                // Ensure the coeffs are calculated
+                volatile T* coefs = FFTPlan<T>::get_twiddle_factors_by_angle<N>();
+                FFTLayer<A>::Init();
+                FFTLayer<B>::Init();
+            }
+
+            static void fft_recurse(T *__restrict__ in, T *__restrict__ out) noexcept {
+                // TODO : may not want to put this on the stack for large FFT steps
+                alignas(16) std::array<T, N> temp_data;
+
+                for (unsigned int i = 0; i < B; i++) {
+                    alignas(16) std::array<T, A> workspace;
+
+                    /* Transpose input data around the first radix A
+                     *  to create B bins of size A.
+                     * 
+                     * We create a single bin and compute its FFT before
+                     *  moving onto the next bin to improve cache locality.
+                     */
+                    for (unsigned int j = 0; j < A; j++) {
+                        workspace[j] = in[i + j * B];
+                    }
+
+                    // Do the A sized FFT on the current bin
+                    FFTLayer<A>::fft_recurse(workspace.data(), out + (i * A));
+                }
+
+                for (unsigned int i = 0; i < A; i++) {
+                    // Cooley Tukey twiddle factors
+                    T *twiddle_factors = FFTPlan<T>::get_twiddle_factors_by_angle<N>();
+
+                    alignas(16) std::array<T, B> workspace;
+                 
+                    /* Same tactic as above to transpose input data around
+                     *  second radix B.
+                     * 
+                     * Here is different than above only in tha before using
+                     *  this input for the recursive FFT, we make sure to
+                     *  adjust it by the appropriate twiddle factor.
+                     */
+                    for (unsigned int j = 0; j < B; j++) {
+                        workspace[j] = m(out[i + j * A], twiddle_factors[i * j]);
+                    }
+
+                    // TODO : fuse this ^ transpose with the transpose that comes below
+
+                    // Do the B sized FFT on the current bin
+                    FFTLayer<B>::fft_recurse(workspace.data(), temp_data.data() + (i * B));
+                }
+
+                // Transpose result back in order
+                for (unsigned int i = 0; i < B; i++) {
+                    for (unsigned int j = 0; j < A; j++) {
+                        out[i * A + j] = temp_data[j * B + i];
+                    }
+                }
+            }
+        };
+
+        // Partial specialization for prime N - uses full DFT matrix
+        template<unsigned int N>
+        requires prime_factor::Prime<N>
+        struct FFTLayer<N> {
+            static constexpr unsigned int A = N;
+            static constexpr unsigned int B = 1;
+            static void Init() {
+                // Ensure the coeffs are calculated
+                volatile T* coefs = FFTPlan<T>::get_dft_matrix_by_angle<N>();
+            }
+            
+            static void fft_recurse(T *__restrict__ in, T *__restrict__ out) noexcept {
+                static T* dft_matrix = FFTPlan<T>::get_dft_matrix_by_angle<N>();
+
+                for (unsigned int i = 0; i < N; i++) {
+                    T temp_ans = {0, 0};
+                    for (unsigned int j = 0; j < N; j++) {
+                        temp_ans += m(in[j], dft_matrix[i * N + j]);
+                    }
+                    out[i] = temp_ans;
+                }
+            }
+        };
+
+        // Hand Written DFT cases serve as base cases for recursive Cooley Tookey
+        // Wrapped in FFTLayer specializations
+        template<>
+        struct FFTLayer<1> {
+            static constexpr unsigned int A = 1;
+            static constexpr unsigned int B = 1;
+            static void Init() {}
+            static void fft_recurse(T *__restrict__ in, T *__restrict__ out) noexcept {
+                // All base cases should avoid the need for this trivial specialization
+                static_assert(false);
+            }
+        };
         
-        // Mixed Radix Cooley Tukey FFT
-        static void fft_recurse(T *__restrict__ in, T *__restrict__ out) noexcept {
-            MCA_START
-            // Base case + direct DFT cases
-            if constexpr (N == 1) {
-                out[0] = in[0];
-            } else if constexpr (N == 2) {
+        template<>
+        struct FFTLayer<2> {
+            static constexpr unsigned int A = 2;
+            static constexpr unsigned int B = 1;
+            static void Init() {}
+            static void fft_recurse(T *__restrict__ in, T *__restrict__ out) noexcept {
                 const auto x_0 = in[0];
                 const auto x_1 = in[1];
                 out[0] = x_0 + x_1;
                 out[1] = x_0 - x_1;
-            } else if constexpr (N == 3) {
-                // TODO : write all math explicitly? See if that gives a speed boost.
+                return;
+            }
+        };
+
+        template<>
+        struct FFTLayer<3> {
+            static constexpr unsigned int A = 3;
+            static constexpr unsigned int B = 1;
+            static void Init() {}
+            static void fft_recurse(T *__restrict__ in, T *__restrict__ out) noexcept {
                 static constexpr T third_root = {-0.5f, -0.866025403784f};
                 const T x_0 = in[0];
                 const T x_1 = in[1];
@@ -119,7 +294,16 @@ namespace FFT {
                 out[0] = x_0 + x_1 + x_2;
                 out[1] = x_0 + m(x_1, third_root) + mc(x_2, third_root);
                 out[2] = x_0 + mc(x_1, third_root) + m(x_2, third_root);
-            } else if constexpr (N == 4) {
+                return;
+            }
+        };
+
+        template<>
+        struct FFTLayer<4> {
+            static constexpr unsigned int A = 4;
+            static constexpr unsigned int B = 1;
+            static void Init() {}
+            static void fft_recurse(T *__restrict__ in, T *__restrict__ out) noexcept {
                 const T x_0 = in[0];
                 const T x_1 = in[1];
                 const T x_2 = in[2];
@@ -137,7 +321,16 @@ namespace FFT {
                     out[1] = a + b;
                     out[3] = a - b;
                 }
-            } else if constexpr (N == 5) {
+                return;
+            }
+        };
+
+        template<>
+        struct FFTLayer<5> {
+            static constexpr unsigned int A = 5;
+            static constexpr unsigned int B = 1;
+            static void Init() {}
+            static void fft_recurse(T *__restrict__ in, T *__restrict__ out) noexcept {
                 static constexpr T root_1 = {0.309016994375, -0.951056516295};
                 static constexpr T root_2 = {-0.809016994375, -0.587785252292};
                 const T x_0 = in[0];
@@ -154,7 +347,16 @@ namespace FFT {
                                mc(x_3, root_1) + m(x_4, root_2);
                 out[4] = x_0 + mc(x_1, root_1) + mc(x_2, root_2) +
                                m(x_3, root_2) + m(x_4, root_1);
-            } else if constexpr (N == 6) {
+                return;
+            }
+        };
+
+        template<>
+        struct FFTLayer<6> {
+            static constexpr unsigned int A = 6;
+            static constexpr unsigned int B = 1;
+            static void Init() {}
+            static void fft_recurse(T *__restrict__ in, T *__restrict__ out) noexcept {
                 static constexpr float r_a = 0.5f;
                 static constexpr float r_b = -0.866025403784f;
                 const T x_0 = in[0];
@@ -183,7 +385,16 @@ namespace FFT {
                     out[2] = a + m(b, T{-r_a, r_b}) + m(c, T{-r_a, -r_b});
                     out[4] = a + m(b, T{-r_a, -r_b}) + m(c, T{-r_a, r_b});
                 }
-            } else if constexpr (N == 7) {
+                return;
+            }
+        };
+
+        template<>
+        struct FFTLayer<7> {
+            static constexpr unsigned int A = 7;
+            static constexpr unsigned int B = 1;
+            static void Init() {}
+            static void fft_recurse(T *__restrict__ in, T *__restrict__ out) noexcept {
                 static constexpr T r_1 = {0.623489801859, -0.781831482468};
                 static constexpr T r_2 = {-0.222520933956, -0.974927912182};
                 static constexpr T r_3 = {-0.900968867902, -0.433883739118};
@@ -198,19 +409,28 @@ namespace FFT {
                 out[1] = x_0 + m(x_1, r_1) + m(x_2, r_2) + m(x_3, r_3) +
                   mc(x_4, r_3) + mc(x_5, r_2) + mc(x_6, r_1);
                 out[2] = x_0 + m(x_1, r_2) + mc(x_2, r_3) + 
-                  mc(x_3, r_1) + m(x_4, r_1) + m(x_5, r_3) +
-                  mc(x_6, r_2);
+                    mc(x_3, r_1) + m(x_4, r_1) + m(x_5, r_3) +
+                    mc(x_6, r_2);
                 out[3] = x_0 + m(x_1, r_3) + mc(x_2, r_1) + m(x_3, r_2) +
-                  mc(x_4, r_2) + m(x_5, r_1) + mc(x_6, r_3); 
+                    mc(x_4, r_2) + m(x_5, r_1) + mc(x_6, r_3); 
                 out[4] = x_0 + mc(x_1, r_3) + m(x_2, r_1) + 
-                  mc(x_3, r_2) + m(x_4, r_2) + mc(x_5, r_1) +
-                  m(x_6, r_3);
+                    mc(x_3, r_2) + m(x_4, r_2) + mc(x_5, r_1) +
+                    m(x_6, r_3);
                 out[5] = x_0 + mc(x_1, r_2) + m(x_2, r_3) + m(x_3, r_1) +
-                  mc(x_4, r_1) + mc(x_5, r_3) + m(x_6, r_2);
+                    mc(x_4, r_1) + mc(x_5, r_3) + m(x_6, r_2);
                 out[6] = x_0 + mc(x_1, r_1) + mc(x_2, r_2) +
-                  mc(x_3, r_3) + m(x_4, r_3) + m(x_5, r_2) +
-                  m(x_6, r_1);
-            } else if constexpr (N == 8) {
+                    mc(x_3, r_3) + m(x_4, r_3) + m(x_5, r_2) +
+                    m(x_6, r_1);
+                return;
+            }
+        };
+
+        template<>
+        struct FFTLayer<8> {
+            static constexpr unsigned int A = 8;
+            static constexpr unsigned int B = 1;
+            static void Init() {}
+            static void fft_recurse(T *__restrict__ in, T *__restrict__ out) noexcept {
                 static constexpr float c = 0.707106781187f;
                 static constexpr T eighth_root = {c,c};
                 static constexpr auto forth_root = [](T x){
@@ -262,175 +482,37 @@ namespace FFT {
                         out[7] = (a_0 - a_1) + m(b_0 - b_1, eighth_root); 
                     }
                 }
-            } else if constexpr (A == 1 || B == 1) { // Do the full DFT
-                auto dft_matrix = gen_coefs_by_angle();
-                std::array<T, N> temp_data;
-
-                for (unsigned int i = 0; i < N; i++) {
-                    T temp_ans = {0, 0};
-                    for (unsigned int j = 0; j < N; j++) {
-                        temp_ans += m(in[j], dft_matrix[i * N + j]);
-                    }
-                    out[i] = temp_ans;
-                }
-            } else { // Do a recursive step of a mixed radix FFT
-                // TODO : may not want to put this on the stack for large FFT steps
-                alignas(16) std::array<T, N> temp_data;
-
-                for (unsigned int i = 0; i < B; i++) {
-                    alignas(16) std::array<T, A> workspace;
-
-                    /* Transpose input data around the first radix A
-                     *  to create B bins of size A.
-                     * 
-                     * We create a single bin and compute its FFT before
-                     *  moving onto the next bin to improve cache locality.
-                     */
-                    for (unsigned int j = 0; j < A; j++) {
-                        workspace[j] = in[i + j * B];
-                    }
-
-                    // Do the A sized FFT on the current bin
-                    FFTPlan<A, T>::fft_recurse(workspace.data(), out + (i * A));
-                }
-
-                for (unsigned int i = 0; i < A; i++) {
-                    // Cooley Tukey twiddle factors
-                    T *twiddle_factors = gen_coefs_by_angle();
-
-                    alignas(16) std::array<T, B> workspace;
-                 
-                    /* Same tactic as above to transpose input data around
-                     *  second radix B.
-                     * 
-                     * Here is different than above only in tha before using
-                     *  this input for the recursive FFT, we make sure to
-                     *  adjust it by the appropriate twiddle factor.
-                     */
-                    for (unsigned int j = 0; j < B; j++) {
-                        workspace[j] = m(out[i + j * A], twiddle_factors[i * j]);
-                    }
-
-                    // Do the B sized FFT on the current bin
-                    FFTPlan<B, T>::fft_recurse(workspace.data(), temp_data.data() + (i * B));
-                }
-
-                // Transpose result back in order
-                for (unsigned int i = 0; i < B; i++) {
-                    for (unsigned int j = 0; j < A; j++) {
-                        out[i * A + j] = temp_data[j * B + i];
-                    }
-                }
+                return;
             }
-            MCA_END
+        };
 
-            return;
-        } 
-         
         private:
-        // NOTE : coeffs with either method can be calculated as they are needed in the loops that
-        //   calculate the actual DFT components, but calculating them ahead of time reduces
-        //   work done in the DFT itself for the angle based method, and grealy reduces loop
-        //   dependencies for the multiplication based method.
-        // static float32x2_t* coefs;
-        
-        // NOTE : Although this is technically correct to calculate coeffs, it is not as
-        //   numerically stable as the angle based method.
-        static T* get_coefs_by_mult() {
-            static T* coefs = []{
-                T* result = new T[N * A];
-            
-                // Setup constant factors for incremental rotations by multiplication
-                constexpr float small_angle = 
-                    static_cast<float>(NegTwoPI / static_cast<double>(N));
-                constexpr float big_angle = 
-                    static_cast<float>(NegTwoPI / static_cast<double>(A));
-                const T small_inc = {std::cosf(small_angle), std::sinf(small_angle)};
-                const T big_inc = {std::cosf(big_angle), std::sinf(big_angle)};
-        
-                T i_factor = {1, 0};
-                for (std::size_t i = 0; i < B; i++) {
-                    T j_factor = i_factor;
-                    for (std::size_t j = 0; j < A; j++) {
-                        T k_factor = {1, 0};
-                        for (std::size_t k = 0; k < A; k++) {
-                            result[i * A * A + j * A + k] = k_factor;
-                            k_factor = m(k_factor, j_factor);
-                        }
-                        j_factor = m(j_factor, big_inc);
-                    }
-                    i_factor = m(i_factor, small_inc);
-                }
-                return result;
-            }();
-            return coefs;
-        }
-        
-        static T gen_factor_by_angle(std::size_t i, std::size_t j, std::size_t k) {
-            const double angle = NegTwoPI * static_cast<double>(i * (k + j * B)) / static_cast<double>(N);
-            return {static_cast<float>(std::cos(angle)), static_cast<float>(std::sin(angle))};
-        }
+        // Coeffs calculated ahead of time trades memory for speed.
+        //   Since Coeffs are roots of unity they could also be multiplied
+        //   together within loops to generate them as needed, but this 
+        //   is emperically found to be not numerically stable enough.
+        //   It is better to generate them with this angle based method for 
+        //   numerical stablility. 
 
         // TODO : use a cleaner way to hold coefs at class rather than object level
-        static T* gen_coefs_by_angle() {
+        template<unsigned int N>
+        static T* get_dft_matrix_by_angle() {
             static T* coefs = []{
-              if constexpr (A == 1 || B == 1) { // DFT matrix
                 T* result = new T[N * N];
-                for (std::size_t i = 0; i < N; i++) {
-                  for (std::size_t j = 0; j < N; j++) {
-                    const double angle = 
-                      NegTwoPI * static_cast<double>((i * j) % N) / static_cast<double>(N);
-                        result[i * N + j] = T{static_cast<float>(std::cos(angle)),
-                                              static_cast<float>(std::sin(angle))};
-                  }
-                }
+                populate_dft_matrix_by_angle<T, N>(result); 
                 return result;
-              } else { // Split Radix FFT Twiddle factors
-                T* result = new T[N];
-                for (std::size_t i = 0; i < N; i++) {
-                  const double angle = 
-                      NegTwoPI * static_cast<double>(i) / static_cast<double>(N);
-                  result[i] = T{static_cast<float>(std::cos(angle)), static_cast<float>(std::sin(angle))};
-                }
-                return result;
-              }
             }();
             return coefs;
-        } 
+        };
+
+        template<unsigned int N>
+        static T* get_twiddle_factors_by_angle() {
+            static T* coefs = []{
+                T* result = new T[N];
+                populate_twiddle_factors_by_angle<T, N>(result); 
+                return result;
+            }();
+            return coefs;
+        };
     }; 
-
-    template <typename T>
-    constexpr void wave_gen(T *time_domain, T *freq_domain,
-        std::size_t N,
-        unsigned int f = 1,
-        unsigned int phase = 0,
-        unsigned int amp = 1) {
-        for (unsigned int i = 0; i < N; i++) {
-            const float angle = static_cast<float>(TwoPI) * static_cast<float>((i * f) + phase)
-                                  / static_cast<float>(N);
-            time_domain[i] += T{std::cosf(angle), std::sinf(angle)} * static_cast<float>(amp);
-        }
-        const float angle = static_cast<float>(TwoPI) * 
-                                  (static_cast<float>(phase) / static_cast<float>(N));
-        freq_domain[f] += T{std::cosf(angle), std::sinf(angle)} * static_cast<float>(amp);
-    } 
-
-    template <typename T>
-    constexpr void wave_gen_lcg(T *time_domain, T *freq_domain, unsigned int N) {
-        if (N < 13) {
-            if (N > 7) wave_gen(time_domain, freq_domain, N, 7, 2, 1);
-            if (N > 5) wave_gen(time_domain, freq_domain, N, 5, 2, 1);
-            if (N > 4) wave_gen(time_domain, freq_domain, N, 4, 3, 2);
-            if (N > 3) wave_gen(time_domain, freq_domain, N, 3, 2, 1);
-            wave_gen(time_domain, freq_domain, N, 1, 1, 1);
-            return;
-        } else {
-            for (unsigned int i = 0; i < 13; i++) {
-                wave_gen(time_domain, freq_domain, N,
-                    ((i + 7) * 3) % N,
-                    ((i + 5) * 11) % N,
-                    ((i + 11) * 13) % N);
-            }
-        }
-    }
 }

--- a/src/prime_factor.hpp
+++ b/src/prime_factor.hpp
@@ -14,6 +14,9 @@ namespace prime_factor {
         return N;
     }
 
+    template<unsigned int n>
+    concept Prime = (get_prime_factor(n) == n);
+
     // NOTE : This is only for testing the get_prime_factor function
     constexpr std::array<unsigned int, 64> prime_factorization(unsigned int n) {
         // Take care of "degenerate" edge cases

--- a/test/fft_tests.cpp
+++ b/test/fft_tests.cpp
@@ -65,11 +65,14 @@ TEST_CASE("FFT Basic Small Input") {
     for (std::size_t i = 0; i < M; i++)
         time_domain2_copy[i] = time_domain2[i];
 
+    FFT::FFTPlan<FFT::StdComplexWrap<float>>::Init<N>();
+    FFT::FFTPlan<FFT::StdComplexWrap<float>>::Init<M>();
+
     // modify in place to frequency domain
-    FFT::FFTPlan<N, FFT::StdComplexWrap<float>>::fft(
+    FFT::FFTPlan<FFT::StdComplexWrap<float>>::fft<N>(
         static_cast<FFT::StdComplexWrap<float>*>(time_domain1.data()),
         static_cast<FFT::StdComplexWrap<float>*>(resp.data()));
-    FFT::FFTPlan<M, FFT::StdComplexWrap<float>>::fft(
+    FFT::FFTPlan<FFT::StdComplexWrap<float>>::fft<M>(
         static_cast<FFT::StdComplexWrap<float>*>(time_domain2.data()),
         static_cast<FFT::StdComplexWrap<float>*>(resp2.data()));
 
@@ -87,10 +90,10 @@ TEST_CASE("FFT Basic Small Input") {
     CHECK(max_diff < 6e-6);
 
     // modify in place back to time domain
-    FFT::FFTPlan<N, FFT::StdComplexWrap<float>>::ifft(
+    FFT::FFTPlan<FFT::StdComplexWrap<float>>::ifft<N>(
         static_cast<FFT::StdComplexWrap<float>*>(resp.data()),
         static_cast<FFT::StdComplexWrap<float>*>(time_domain1.data()));
-    FFT::FFTPlan<M, FFT::StdComplexWrap<float>>::ifft(
+    FFT::FFTPlan<FFT::StdComplexWrap<float>>::ifft<M>(
         static_cast<FFT::StdComplexWrap<float>*>(resp2.data()),
         static_cast<FFT::StdComplexWrap<float>*>(time_domain2.data()));
     
@@ -122,10 +125,11 @@ std::pair<float, float> fft_opt_tester() {
         time_domain_copy[i] = time_domain[i];
     
     // Init
-    volatile auto fft_plan = FFT::FFTPlan<N, FFT::Complex>();
+
+    FFT::FFTPlan<FFT::StdComplexWrap<float>>::Init<N>();
     
     // modify in place to frequency domain
-    FFT::FFTPlan<N, FFT::Complex>::fft(time_domain.data(), resp.data());
+    FFT::FFTPlan<FFT::Complex>::fft<N>(time_domain.data(), resp.data());
 
     // Check Outputs
     float max_diff = 0;
@@ -136,7 +140,7 @@ std::pair<float, float> fft_opt_tester() {
     }
 
     // modify in place back to time domain
-    FFT::FFTPlan<N, FFT::Complex>::ifft(resp.data(), time_domain.data());
+    FFT::FFTPlan<FFT::Complex>::ifft<N>(resp.data(), time_domain.data());
     
     // Check Outputs
     float max_inverse_diff = 0;


### PR DESCRIPTION
This structure should make it easier to fuse the transpose steps between consecutive "layers" in the Mixed Cooley Tookey algorithm. Without this, it appears time is lost in doing two separate transposes right after/ before the twiddle factors are applied. These transposes and intermediate multiplication should be fused into one load-multiply-store operation. 