### PR TITLE
Fused Tail Transposes

### DIFF
--- a/src/fft.hpp
+++ b/src/fft.hpp
@@ -149,7 +149,7 @@ namespace FFT {
             } else {
                 std::array<T, N> temp_data;
                 FFTLayer<N>::fft_recurse(in, temp_data.data());
-                FFTLayer<N>::transpose(temp_data.data(), out);
+                FFTLayer<N>::transpose(temp_data.data(), out, 1);
             }
 
             // Normalize
@@ -173,7 +173,7 @@ namespace FFT {
             } else {
                 std::array<T, N> temp_data;
                 FFTLayer<N>::fft_recurse(in, temp_data.data());
-                FFTLayer<N>::transpose(temp_data.data(), out);
+                FFTLayer<N>::transpose(temp_data.data(), out, 1);
             }
 
             for (std::size_t i = 0; i < N; i++)
@@ -204,24 +204,16 @@ namespace FFT {
                 static_assert(FFTLayer<A>::base_case);
             }
 
-            static void transpose(T *__restrict__ in, T *__restrict__ out) noexcept {
-                std::array<T, N> temp_data;
-                if constexpr (!FFTLayer<B>::base_case) {
-                    for (unsigned int i = 0; i < A; i++) {
-                        FFTLayer<B>::transpose(in + (i * B), temp_data.data() + (i * B)); 
-                    }
-                }
-                
+            static void transpose(T *__restrict__ in, T *__restrict__ out, unsigned int skip) noexcept {
                 // Transpose result back in order
-                for (unsigned int i = 0; i < B; i++) {
-                    for (unsigned int j = 0; j < A; j++) {
-                        if constexpr (FFTLayer<B>::base_case) {
-                            out[i * A + j] = in[j * B + i];
-                        } else {
-                            out[i * A + j] = temp_data[j * B + i];
-                        }
+                for (unsigned int i = 0; i < A; i++) {
+                    if constexpr (B == 1) {
+                        out[skip * i] = in[i];
+                    } else {
+                        FFTLayer<B>::transpose(in + (i * B), out + skip * i, A * skip);
                     }
                 }
+                return;
             }
 
             static void fft_recurse(T *__restrict__ in, T *__restrict__ out) noexcept {
@@ -285,6 +277,18 @@ namespace FFT {
                 volatile T* coefs = FFTPlan<T>::get_dft_matrix_by_angle<N>();
             }
             
+            static void transpose(T *__restrict__ in, T *__restrict__ out, unsigned int skip) noexcept {
+                // Transpose result back in order
+                for (unsigned int i = 0; i < A; i++) {
+                    if constexpr (B == 1) {
+                        out[skip * i] = in[i];
+                    } else {
+                        FFTLayer<B>::transpose(in + (i * B), out + skip * i, A * skip);
+                    }
+                }
+                return;
+            }
+            
             static void fft_recurse(T *__restrict__ in, T *__restrict__ out) noexcept {
                 static T* dft_matrix = std::assume_aligned<MY_CPU_LOAD_SIZE>(
                     FFTPlan<T>::get_dft_matrix_by_angle<N>());
@@ -328,6 +332,17 @@ namespace FFT {
             static constexpr unsigned int B = 1;
             static constexpr bool base_case = true;
             static void Init() {}
+            static void transpose(T *__restrict__ in, T *__restrict__ out, unsigned int skip) noexcept {
+                // Transpose result back in order
+                for (unsigned int i = 0; i < A; i++) {
+                    if constexpr (B == 1) {
+                        out[skip * i] = in[i];
+                    } else {
+                        FFTLayer<B>::transpose(in + (i * B), out + skip * i, A * skip);
+                    }
+                }
+                return;
+            }
             static void fft_recurse(T *__restrict__ in, T *__restrict__ out) noexcept {
                 const auto x_0 = in[0];
                 const auto x_1 = in[1];
@@ -343,6 +358,17 @@ namespace FFT {
             static constexpr unsigned int B = 1;
             static constexpr bool base_case = true;
             static void Init() {}
+            static void transpose(T *__restrict__ in, T *__restrict__ out, unsigned int skip) noexcept {
+                // Transpose result back in order
+                for (unsigned int i = 0; i < A; i++) {
+                    if constexpr (B == 1) {
+                        out[skip * i] = in[i];
+                    } else {
+                        FFTLayer<B>::transpose(in + (i * B), out + skip * i, A * skip);
+                    }
+                }
+                return;
+            }
             static void fft_recurse(T *__restrict__ in, T *__restrict__ out) noexcept {
                 static constexpr T third_root = {-0.5f, -0.866025403784f};
                 const T x_0 = in[0];
@@ -361,6 +387,17 @@ namespace FFT {
             static constexpr unsigned int B = 1;
             static constexpr bool base_case = true;
             static void Init() {}
+            static void transpose(T *__restrict__ in, T *__restrict__ out, unsigned int skip) noexcept {
+                // Transpose result back in order
+                for (unsigned int i = 0; i < A; i++) {
+                    if constexpr (B == 1) {
+                        out[skip * i] = in[i];
+                    } else {
+                        FFTLayer<B>::transpose(in + (i * B), out + skip * i, A * skip);
+                    }
+                }
+                return;
+            }
             static void fft_recurse(T *__restrict__ in, T *__restrict__ out) noexcept {
                 const T x_0 = in[0];
                 const T x_1 = in[1];
@@ -389,6 +426,17 @@ namespace FFT {
             static constexpr unsigned int B = 1;
             static constexpr bool base_case = true;
             static void Init() {}
+            static void transpose(T *__restrict__ in, T *__restrict__ out, unsigned int skip) noexcept {
+                // Transpose result back in order
+                for (unsigned int i = 0; i < A; i++) {
+                    if constexpr (B == 1) {
+                        out[skip * i] = in[i];
+                    } else {
+                        FFTLayer<B>::transpose(in + (i * B), out + skip * i, A * skip);
+                    }
+                }
+                return;
+            }
             static void fft_recurse(T *__restrict__ in, T *__restrict__ out) noexcept {
                 static constexpr T root_1 = {0.309016994375, -0.951056516295};
                 static constexpr T root_2 = {-0.809016994375, -0.587785252292};
@@ -416,6 +464,17 @@ namespace FFT {
             static constexpr unsigned int B = 1;
             static constexpr bool base_case = true;
             static void Init() {}
+            static void transpose(T *__restrict__ in, T *__restrict__ out, unsigned int skip) noexcept {
+                // Transpose result back in order
+                for (unsigned int i = 0; i < A; i++) {
+                    if constexpr (B == 1) {
+                        out[skip * i] = in[i];
+                    } else {
+                        FFTLayer<B>::transpose(in + (i * B), out + skip * i, A * skip);
+                    }
+                }
+                return;
+            }
             static void fft_recurse(T *__restrict__ in, T *__restrict__ out) noexcept {
                 static constexpr float r_a = 0.5f;
                 static constexpr float r_b = -0.866025403784f;
@@ -455,6 +514,17 @@ namespace FFT {
             static constexpr unsigned int B = 1;
             static constexpr bool base_case = true;
             static void Init() {}
+            static void transpose(T *__restrict__ in, T *__restrict__ out, unsigned int skip) noexcept {
+                // Transpose result back in order
+                for (unsigned int i = 0; i < A; i++) {
+                    if constexpr (B == 1) {
+                        out[skip * i] = in[i];
+                    } else {
+                        FFTLayer<B>::transpose(in + (i * B), out + skip * i, A * skip);
+                    }
+                }
+                return;
+            }
             static void fft_recurse(T *__restrict__ in, T *__restrict__ out) noexcept {
                 static constexpr T r_1 = {0.623489801859, -0.781831482468};
                 static constexpr T r_2 = {-0.222520933956, -0.974927912182};
@@ -492,6 +562,17 @@ namespace FFT {
             static constexpr unsigned int B = 1;
             static constexpr bool base_case = true;
             static void Init() {}
+            static void transpose(T *__restrict__ in, T *__restrict__ out, unsigned int skip) noexcept {
+                // Transpose result back in order
+                for (unsigned int i = 0; i < A; i++) {
+                    if constexpr (B == 1) {
+                        out[skip * i] = in[i];
+                    } else {
+                        FFTLayer<B>::transpose(in + (i * B), out + skip * i, A * skip);
+                    }
+                }
+                return;
+            }
             static void fft_recurse(T *__restrict__ in, T *__restrict__ out) noexcept {
                 static constexpr float c = 0.707106781187f;
                 static constexpr T eighth_root = {c,c};

--- a/src/fft.hpp
+++ b/src/fft.hpp
@@ -143,7 +143,14 @@ namespace FFT {
         //  and the FFT and IFFT are inverses of each other
         template<unsigned int N>
         static void fft(T *__restrict__ in, T *__restrict__ out) noexcept {
-            FFTLayer<N>::fft_recurse(in, out);
+
+            if constexpr (FFTLayer<N>::base_case) {
+                FFTLayer<N>::fft_recurse(in, out);
+            } else {
+                std::array<T, N> temp_data;
+                FFTLayer<N>::fft_recurse(in, temp_data.data());
+                FFTLayer<N>::transpose(temp_data.data(), out);
+            }
 
             // Normalize
             // FFTW does not normalize, so this loop should be commented
@@ -161,7 +168,13 @@ namespace FFT {
             for (std::size_t i = 0; i < N; i++)
                 in[i] = conj(in[i]);
 
-            FFTLayer<N>::fft_recurse(in, out);
+            if constexpr (FFTLayer<N>::base_case) {
+                FFTLayer<N>::fft_recurse(in, out);
+            } else {
+                std::array<T, N> temp_data;
+                FFTLayer<N>::fft_recurse(in, temp_data.data());
+                FFTLayer<N>::transpose(temp_data.data(), out);
+            }
 
             for (std::size_t i = 0; i < N; i++)
                 out[i] = conj(out[i]);
@@ -178,12 +191,37 @@ namespace FFT {
         struct FFTLayer {
             static constexpr unsigned int A = FFTFactorGen<T>::get_best_factor(N);
             static constexpr unsigned int B = N / A;
+            static constexpr bool base_case = false;
 
             static void Init() {
                 // Ensure the coeffs are calculated
                 volatile T* coefs = FFTPlan<T>::get_twiddle_factors_by_angle<A, B>();
                 FFTLayer<A>::Init();
                 FFTLayer<B>::Init();
+
+                // First layer for A must be a non-recursive base case to make sure
+                //  recursive transpositions are done as expected
+                static_assert(FFTLayer<A>::base_case);
+            }
+
+            static void transpose(T *__restrict__ in, T *__restrict__ out) noexcept {
+                std::array<T, N> temp_data;
+                if constexpr (!FFTLayer<B>::base_case) {
+                    for (unsigned int i = 0; i < A; i++) {
+                        FFTLayer<B>::transpose(in + (i * B), temp_data.data() + (i * B)); 
+                    }
+                }
+                
+                // Transpose result back in order
+                for (unsigned int i = 0; i < B; i++) {
+                    for (unsigned int j = 0; j < A; j++) {
+                        if constexpr (FFTLayer<B>::base_case) {
+                            out[i * A + j] = in[j * B + i];
+                        } else {
+                            out[i * A + j] = temp_data[j * B + i];
+                        }
+                    }
+                }
             }
 
             static void fft_recurse(T *__restrict__ in, T *__restrict__ out) noexcept {
@@ -205,7 +243,7 @@ namespace FFT {
                     }
 
                     // Do the A sized FFT on the current bin
-                    FFTLayer<A>::fft_recurse(workspace.data(), out + (i * A));
+                    FFTLayer<A>::fft_recurse(workspace.data(), temp_data.data() + (i * A));
                 }
 
                 // Cooley Tukey twiddle factors
@@ -226,19 +264,11 @@ namespace FFT {
 
                     // TODO : Need to order twiddle factors so they are accessed linearly
                     for (unsigned int j = 0; j < B; j++) {
-                        workspace[j] = m(out[i + j * A], twiddle_factors[i * B + j]);
+                        workspace[j] = m(temp_data[i + j * A], twiddle_factors[i * B + j]);
                     }
 
                     // Do the B sized FFT on the current bin
-                    FFTLayer<B>::fft_recurse(workspace.data(), temp_data.data() + (i * B));
-                }
-
-                // TODO : fuse all these transposes at the end
-                // Transpose result back in order
-                for (unsigned int i = 0; i < B; i++) {
-                    for (unsigned int j = 0; j < A; j++) {
-                        out[i * A + j] = temp_data[j * B + i];
-                    }
+                    FFTLayer<B>::fft_recurse(workspace.data(), out + (i * B));
                 }
             }
         };
@@ -249,6 +279,7 @@ namespace FFT {
         struct FFTLayer<N> {
             static constexpr unsigned int A = N;
             static constexpr unsigned int B = 1;
+            static constexpr bool base_case = true;
             static void Init() {
                 // Ensure the coeffs are calculated
                 volatile T* coefs = FFTPlan<T>::get_dft_matrix_by_angle<N>();
@@ -273,7 +304,18 @@ namespace FFT {
         struct FFTLayer<1> {
             static constexpr unsigned int A = 1;
             static constexpr unsigned int B = 1;
-            static void Init() {}
+            static constexpr bool base_case = true;
+            static void Init() {
+                // This init should never be called, as this FFTLayer should never be used
+                static_assert(false);
+            }
+            
+            static void transpose(T *__restrict__ in, T *__restrict__ out) noexcept {
+                // This FFTLayer should never be used
+                static_assert(false);
+            }
+
+
             static void fft_recurse(T *__restrict__ in, T *__restrict__ out) noexcept {
                 // All base cases should avoid the need for this trivial specialization
                 static_assert(false);
@@ -284,6 +326,7 @@ namespace FFT {
         struct FFTLayer<2> {
             static constexpr unsigned int A = 2;
             static constexpr unsigned int B = 1;
+            static constexpr bool base_case = true;
             static void Init() {}
             static void fft_recurse(T *__restrict__ in, T *__restrict__ out) noexcept {
                 const auto x_0 = in[0];
@@ -298,6 +341,7 @@ namespace FFT {
         struct FFTLayer<3> {
             static constexpr unsigned int A = 3;
             static constexpr unsigned int B = 1;
+            static constexpr bool base_case = true;
             static void Init() {}
             static void fft_recurse(T *__restrict__ in, T *__restrict__ out) noexcept {
                 static constexpr T third_root = {-0.5f, -0.866025403784f};
@@ -315,6 +359,7 @@ namespace FFT {
         struct FFTLayer<4> {
             static constexpr unsigned int A = 4;
             static constexpr unsigned int B = 1;
+            static constexpr bool base_case = true;
             static void Init() {}
             static void fft_recurse(T *__restrict__ in, T *__restrict__ out) noexcept {
                 const T x_0 = in[0];
@@ -342,6 +387,7 @@ namespace FFT {
         struct FFTLayer<5> {
             static constexpr unsigned int A = 5;
             static constexpr unsigned int B = 1;
+            static constexpr bool base_case = true;
             static void Init() {}
             static void fft_recurse(T *__restrict__ in, T *__restrict__ out) noexcept {
                 static constexpr T root_1 = {0.309016994375, -0.951056516295};
@@ -368,6 +414,7 @@ namespace FFT {
         struct FFTLayer<6> {
             static constexpr unsigned int A = 6;
             static constexpr unsigned int B = 1;
+            static constexpr bool base_case = true;
             static void Init() {}
             static void fft_recurse(T *__restrict__ in, T *__restrict__ out) noexcept {
                 static constexpr float r_a = 0.5f;
@@ -406,6 +453,7 @@ namespace FFT {
         struct FFTLayer<7> {
             static constexpr unsigned int A = 7;
             static constexpr unsigned int B = 1;
+            static constexpr bool base_case = true;
             static void Init() {}
             static void fft_recurse(T *__restrict__ in, T *__restrict__ out) noexcept {
                 static constexpr T r_1 = {0.623489801859, -0.781831482468};
@@ -442,6 +490,7 @@ namespace FFT {
         struct FFTLayer<8> {
             static constexpr unsigned int A = 8;
             static constexpr unsigned int B = 1;
+            static constexpr bool base_case = true;
             static void Init() {}
             static void fft_recurse(T *__restrict__ in, T *__restrict__ out) noexcept {
                 static constexpr float c = 0.707106781187f;

--- a/src/fft.hpp
+++ b/src/fft.hpp
@@ -257,7 +257,6 @@ namespace FFT {
                      *  adjust it by the appropriate twiddle factor.
                      */
 
-                    // TODO : Need to order twiddle factors so they are accessed linearly
                     for (unsigned int j = 0; j < B; j++) {
                         workspace[j] = m(temp_data[i + j * A], twiddle_factors[i * B + j]);
                     }


### PR DESCRIPTION
This PR primarily fuses the sequential loops that accumulate at the end of all the recursive FFT template instantiations into one nested transpose. Although this configuration has the same performance, as measured on a MacBook Pro, as previous versions it opens the door to organize the FFT as a whole into discrete "layers". The goal is that discrete "layers" will be easier to optimize and parallelize in future versions.