### PR TITLE
Fused inner transposes with linear reads

### DIFF
--- a/src/complex_types.hpp
+++ b/src/complex_types.hpp
@@ -33,6 +33,10 @@ namespace FFT {
             return {a[0] * b, a[1] * b};
         }
         
+        friend constexpr Complex operator/(const Complex& a, float b) noexcept {
+            return {a[0] / b, a[1] / b};
+        }
+        
         friend constexpr Complex operator*(const Complex& a, const Complex& b) noexcept {
             return {a[0] * b[0], a[1] * b[1]};
         }


### PR DESCRIPTION
This PR has some readability improvements, but focuses on improving transpositions and reducing the overall memory required for the FFT. Transpositions between FFT layers have been fused into one nested loop which reduces data movement between arrays, reduces the number of intermediate data arrays required as workspace, simplifies the process of making all reads utilize linear data access, and opens the door for effective tiling in the future (if required). This fusion also allowed the number of intermediate workspace arrays and data movement (CPU IO) across the FFT to be reduced.